### PR TITLE
Strip dirname of program name only if path is absolute

### DIFF
--- a/chaperone/cutil/syslog.py
+++ b/chaperone/cutil/syslog.py
@@ -280,7 +280,8 @@ class SyslogServer(Server):
         else:
             logattrs = match.groupdict()
             pri = int(logattrs['pri'])
-            logattrs['tag'] = os.path.basename(logattrs['tag'])
+            if logattrs['tag'][0] == '/':
+                logattrs['tag'] = os.path.basename(logattrs['tag'])
 
         logattrs['raw'] = msg
 


### PR DESCRIPTION
* Some daemons (like postfix) add prefix to program names.
  Ex: postfix/smtpd. This prefix must not be removed.
* If the path is absolute (start with a /) we can remove dirname
  to only keep program name